### PR TITLE
Use AvailabilityTest for packages without binaries

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -183,19 +183,7 @@ Dependencies := rec(
                       
 ),
 
-#AvailabilityTest := ReturnTrue,
-AvailabilityTest := function()
-  local path, file;
-    # test for existence of the compiled binary
-    path:= DirectoriesPackagePrograms( "nock" );
-    file:= Filename( path, "hello" );
-    if file = fail then
-      LogPackageLoadingMessage( PACKAGE_WARNING,
-          [ "The program `hello' is not compiled,",
-            "`HelloWorld()' is thus unavailable." ] );
-    fi;
-    return true;
-  end,
+AvailabilityTest := ReturnTrue,
 
 BannerString := Concatenation( 
     "----------------------------------------------------------------\n",


### PR DESCRIPTION
The current version of the test is borrowed from a package with an external binary. This is no applicable to NoCK - it can use a trivial test instead.