### PR TITLE
Replace number by volume in NoCKbib.xml

### DIFF
--- a/doc/NoCKbib.xml
+++ b/doc/NoCKbib.xml
@@ -58,7 +58,7 @@
   <title>Regular subalgebras and nilpotent orbits of real graded Lie algebras</title>
   <journal>Journal of Algebra</journal>
   <year>2015</year>
-  <number>423</number>
+  <volume>423</volume>
   <pages>1044&ndash;1079</pages>
 </article></entry>
 </file>


### PR DESCRIPTION
This should stop BibTeX from complaining about a missing volume number, too.